### PR TITLE
Add PRIM&R 2024 workshop to XR & Safety section

### DIFF
--- a/xrandsafety.html
+++ b/xrandsafety.html
@@ -110,10 +110,17 @@
 
             <hr class="my-12 md:my-16 border-gray-200">
 
-            <!-- Research Papers & Publications -->
+            <!-- Research Papers, Publications & Workshops -->
             <section class="content-section">
-                <h2 class="text-3xl md:text-5xl font-semibold mb-12 text-center text-gray-800">Research Papers & Publications</h2>
+                <h2 class="text-3xl md:text-5xl font-semibold mb-12 text-center text-gray-800">Research Papers, Publications & Workshops</h2>
                 <div class="space-y-8">
+                    <div>
+                        <h3 class="text-2xl font-bold text-gray-800 mb-2">Immersive Technologies and Human Subjects Protections (2024)</h3>
+                        <p class="text-sm text-gray-500 mb-2">Workshop Speaker | PRIM&R 2024 Annual Conference</p>
+                        <p class="text-gray-700 mb-3">Co-facilitated workshop on risks and safeguards for human subjects research using immersive technologies, covering data management practices, psychological safety measures, and ethical considerations for VR, wearable sensors, and spatial computing research.</p>
+                        <a href="https://primr24.eventscribe.net/SearchByBucket.asp?f=CustomPresfield1&bm=W&pfp=BrowsebyWorkshops" target="_blank" class="text-blue-600 hover:underline">View Workshop Details</a>
+                    </div>
+
                     <div>
                         <h3 class="text-2xl font-bold text-gray-800 mb-2">Understanding the Interdependence of Trust Factors and Usability in Cybersecurity and Privacy for Immersive Technologies (2024)</h3>
                         <p class="text-sm text-gray-500 mb-2">Co-author | Presented at NIST SOUPS 2024</p>


### PR DESCRIPTION
Updated Research Papers & Publications section to include workshop presentation on Immersive Technologies and Human Subjects Protections at PRIM&R 2024 Annual Conference.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated section title to “Research Papers, Publications & Workshops.”
  * Added a new workshop entry: “Immersive Technologies and Human Subjects Protections (2024)” with description and a “View Workshop Details” link (opens in a new tab).
* **Style**
  * Reformatted the NIST-related links within the existing publication entry for clearer presentation; “Report of the Virtual Workshop…” link is now embedded in the description, and “View Publication” remains intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->